### PR TITLE
feat: Implement backend for Gemini free time search

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -32,10 +32,11 @@ Check items off as they are completed:
 
 ### Advanced Gemini API Features
 - [ ] **Automatic Tagging/Categorization:** Gemini API analyzes event content (e.g., "meeting," "dinner," "exercise") and suggests tags/categories.
-- [ ] **Free Time Search/Suggestion:**
-    - [ ] Natural language queries like, "What 2-hour slots are free next Monday afternoon?"
-    - [ ] Gemini API analyzes the calendar and presents available times.
-    - [ ] Assists in coordinating schedules for multiple participants (integrates with sharing).
+- [~] **Free Time Search/Suggestion:** (Backend API and service implemented)
+    - [x] Backend supports natural language queries like, "What 2-hour slots are free next Monday afternoon?"
+    - [x] Backend logic for Gemini API to analyze calendar and identify available times is implemented.
+    - [ ] UI for displaying/using these suggestions is pending.
+    - [ ] Assists in coordinating schedules for multiple participants (integrates with sharing). (Future scope)
 - [ ] **Related Information:**
     - [ ] Based on event location, Gemini API provides weather forecasts, traffic information, nearby restaurant suggestions.
     - [ ] Suggests news articles or documents related to event content (with user permission).
@@ -76,8 +77,10 @@ Check items off as they are completed:
         -   [x] **Search Functionality:** Implemented comprehensive event search, allowing users to filter events by keywords (in title and description), specific date ranges (period), and associated tags. Includes backend logic, API endpoints, frontend UI in Dashboard, and unit/integration tests.
         -   [x] **Recurring Event Settings:** Added support for creating and managing recurring events. UI allows defining daily and weekly patterns, intervals, and end dates, generating RRULE strings. Backend stores RRULEs and expands occurrences for display. Includes model changes, service logic, API updates, frontend form modifications, and unit/integration tests.
         -   [x] Documentation (`README.md`, `SYSTEM_OVERVIEW.md`) updated for these features.
-3.  [ ] **Gradual Addition of Gemini API Features:**
-    *   [ ] Sequentially add free time search, automatic event tagging, related information display.
+3.  [~] **Gradual Addition of Gemini API Features:** (Free time search backend started)
+    *   [x] **Free time search/suggestion:** Backend service and API endpoint implemented. Unit tests added.
+    *   [ ] **Automatic Tagging/Categorization:** Design and implement backend service and API endpoint.
+    *   [ ] **Related Information Display (Weather, Traffic, etc.):** Design and implement backend service and API endpoint.
     *   [ ] Improve based on user feedback.
 4.  [ ] **UI/UX Improvement:**
     *   [ ] Continuously enhance the user interface and user experience.

--- a/gemini_scheduler_app/backend/tests/test_gemini_service.py
+++ b/gemini_scheduler_app/backend/tests/test_gemini_service.py
@@ -1,0 +1,179 @@
+# gemini_scheduler_app/backend/tests/test_gemini_service.py
+import pytest
+from unittest.mock import MagicMock
+import json
+from datetime import datetime
+
+# Adjust import path as per your project structure
+# Assuming tests are run from the 'backend' directory or PYTHONPATH is set up accordingly
+from services.gemini_service import find_free_time_slots_with_gemini
+
+# Test cases for find_free_time_slots_with_gemini
+
+def test_find_free_time_successful_response(monkeypatch):
+    """
+    Tests successful retrieval and parsing of free time slots from Gemini.
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    expected_slots = [
+        {"start_time": "2024-08-01T10:00:00", "end_time": "2024-08-01T11:00:00"},
+        {"start_time": "2024-08-01T14:00:00", "end_time": "2024-08-01T15:00:00"}
+    ]
+    mock_gemini_response.text = json.dumps(expected_slots)
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    user_query = "Find a 1-hour slot tomorrow morning"
+    events_json = json.dumps([
+        {"title": "Existing Meeting", "start_time": "2024-08-01T09:00:00", "end_time": "2024-08-01T09:30:00"}
+    ])
+
+    result = find_free_time_slots_with_gemini(user_query, events_json)
+
+    assert result == expected_slots
+    mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once()
+    # Check that today's date was included in the prompt
+    called_prompt = mock_model_instance.generate_content.call_args[0][0]
+    assert datetime.now().strftime('%Y-%m-%d') in called_prompt
+
+def test_find_free_time_api_key_not_configured(monkeypatch):
+    """
+    Tests the scenario where the Gemini API key is not configured.
+    """
+    mock_get_gemini_model = MagicMock(return_value=None)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+
+    assert isinstance(result, dict)
+    assert result.get("error") == "Gemini API not configured"
+    assert result.get("detail") == "API key missing or invalid."
+    mock_get_gemini_model.assert_called_once()
+
+def test_find_free_time_gemini_api_error(monkeypatch):
+    """
+    Tests handling of an error during the Gemini API call.
+    """
+    mock_model_instance = MagicMock()
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    mock_model_instance.generate_content.side_effect = Exception("Gemini network error")
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+
+    assert isinstance(result, dict)
+    assert result.get("error") == "Gemini API error"
+    assert result.get("detail") == "Gemini network error"
+    # Ensure raw_response is included, even if it's a generic message for this type of error
+    assert "raw_response" in result
+    mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once()
+
+def test_find_free_time_malformed_json_response(monkeypatch):
+    """
+    Tests handling of a malformed JSON response from Gemini.
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    malformed_json_text = "This is not JSON, it's just a string {oops"
+    mock_gemini_response.text = malformed_json_text
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+
+    assert isinstance(result, dict)
+    assert result.get("error") == "Invalid JSON response from Gemini"
+    assert result.get("raw_response") == malformed_json_text
+    assert "detail" in result # Should contain the JSONDecodeError string
+    mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once()
+
+def test_find_free_time_empty_array_response(monkeypatch):
+    """
+    Tests handling of an empty array JSON response from Gemini (no slots found).
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    mock_gemini_response.text = "[]"
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+
+    assert result == []
+    mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once()
+
+def test_find_free_time_json_wrapped_in_markdown_ticks(monkeypatch):
+    """
+    Tests successful parsing when JSON is wrapped in markdown backticks.
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    expected_slots = [{"start_time": "2024-08-05T10:00:00", "end_time": "2024-08-05T11:00:00"}]
+    # Test with ```json prefix and ``` suffix
+    mock_gemini_response.text = f"```json\n{json.dumps(expected_slots)}\n```"
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+    assert result == expected_slots
+    mock_get_gemini_model.assert_called_once() # Should be called once per test
+    mock_model_instance.generate_content.assert_called_once()
+
+
+def test_find_free_time_json_wrapped_in_simple_markdown_ticks(monkeypatch):
+    """
+    Tests successful parsing when JSON is wrapped in simple markdown backticks.
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    expected_slots = [{"start_time": "2024-08-06T12:00:00", "end_time": "2024-08-06T13:00:00"}]
+    # Test with ``` prefix and ``` suffix but no "json" language identifier
+    mock_gemini_response.text = f"```{json.dumps(expected_slots)}```" # One line, simple ticks
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    # Reset and re-assign mock_get_gemini_model for this specific test case, or ensure it's fresh
+    # if tests are run in isolation or monkeypatch is function-scoped (which it is by default in pytest)
+    current_mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', current_mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+    assert result == expected_slots
+    current_mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once() # This will be the second call if instance is shared and not reset
+
+def test_find_free_time_empty_string_response_handled_as_empty_list(monkeypatch):
+    """
+    Tests that an empty string response from Gemini is handled as an empty list.
+    """
+    mock_model_instance = MagicMock()
+    mock_gemini_response = MagicMock()
+    mock_gemini_response.text = "" # Empty string
+    mock_model_instance.generate_content.return_value = mock_gemini_response
+
+    mock_get_gemini_model = MagicMock(return_value=mock_model_instance)
+    monkeypatch.setattr('services.gemini_service.get_gemini_model', mock_get_gemini_model)
+
+    result = find_free_time_slots_with_gemini("any query", "[]")
+
+    assert result == [] # As per function logic, empty string should result in empty list
+    mock_get_gemini_model.assert_called_once()
+    mock_model_instance.generate_content.assert_called_once()
+
+# To run these tests, navigate to the `backend` directory and run `pytest`
+# Ensure services/gemini_service.py can be imported from that location.
+# Example: python -m pytest tests/test_gemini_service.py
+# (or simply `pytest` if __init__.py files are set up correctly for package discovery)


### PR DESCRIPTION
Adds the backend functionality for the "Free Time Search/Suggestion" feature using the Gemini API.

Key changes include:
- A new function `find_free_time_slots_with_gemini` in `gemini_service.py` that takes your natural language query and existing event schedule, queries the Gemini API, and returns potential free time slots.
- A new API endpoint POST `/api/events/find-free-time` in `event.py` to expose this functionality. This endpoint fetches your events for a given range (defaulting to 7 days) and uses the Gemini service to find available slots.
- Unit tests for both the new service function (`test_gemini_service.py`) and the API endpoint (`test_event_api.py`), covering various scenarios including successful calls, error handling, and API key configuration.
- Updated `PROJECT_PROGRESS.md` to reflect the completion of the backend portion of this feature.

This is the first feature implemented as part of the "Gradual Addition of Gemini API Features" development step.