### PR TITLE
feat: Implement Gemini-powered event summary and update docs

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -17,10 +17,10 @@ Check items off as they are completed:
     - [x] Example: "Meeting with Mr. A in Shibuya tomorrow at 14:00, also set a reminder for document preparation."
     - [x] Gemini API interprets and suggests entries for date, time, location, attendees, content, and reminders.
     - [ ] Users confirm/modify suggestions before saving.
-- [ ] **Event Display:**
-    - [ ] Calendar formats (monthly, weekly, daily).
-    - [ ] List format.
-    - [ ] Gemini API-powered summary (e.g., "You have 3 important events today: a morning meeting, an afternoon client visit, and an evening deadline for document submission.").
+- [x] **Event Display:**
+    - [x] Calendar formats (monthly, weekly, daily).
+    - [x] List format.
+    - [x] Gemini API-powered summary (e.g., "You have 3 important events today: a morning meeting, an afternoon client visit, and an evening deadline for document submission.").
 - [x] **Edit/Delete:** Intuitive modification and deletion of events. (Marking as complete as it's a basic CRUD op typically done with event creation)
 - [x] **Recurring Events:** Settings for daily, weekly, monthly, yearly repetitions. (Implemented daily/weekly UI, backend supports full RRULE)
 - [x] **Search:** Keyword, period, and tag-based event search.

--- a/gemini_scheduler_app/frontend/src/services/eventService.js
+++ b/gemini_scheduler_app/frontend/src/services/eventService.js
@@ -72,6 +72,18 @@ const eventService = {
             requestBody.end_date = endDate;
         }
         return axios.post(`${API_URL}/find-free-time`, requestBody, { headers: getAuthHeaders() });
+    },
+
+    // New function for getting event summary
+    getEventSummary: (date = null) => {
+        const params = {};
+        if (date) {
+            params.date = date;
+        }
+        return axios.get(`${API_URL}/summary`, {
+            headers: getAuthHeaders(),
+            params: params
+        });
     }
 };
 export default eventService;


### PR DESCRIPTION
I've implemented a feature to display a Gemini API-powered summary of events.

Backend:
- I added a new API endpoint GET /api/events/summary that fetches events for a given date (defaulting to today) and uses Gemini to generate a natural language summary.
- I added a new service function in GeminiService to interact with the Gemini API for generating summaries.
- I included unit tests for the new service function and API endpoint.

Frontend:
- I added a new service function in EventService to call the summary API.
- I updated the Dashboard component to fetch and display the event summary for the current day.
- I included loading and error states for the summary display.
- I added unit tests for the Dashboard component's summary feature.

Documentation:
- I updated PROJECT_PROGRESS.md to mark the "Event Display" features (calendar formats, list format, and Gemini API-powered summary) as complete.
- I reviewed SYSTEM_OVERVIEW.md; the existing description for the summary feature was deemed sufficient.