### PR TITLE
feat: Configure E2E tests for sharded execution

### DIFF
--- a/e2e_tests/package.json
+++ b/e2e_tests/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test:e2e:shard1": "PLAYWRIGHT_SHARD_COUNT=3 PLAYWRIGHT_SHARD_INDEX=1 playwright test",
+    "test:e2e:shard2": "PLAYWRIGHT_SHARD_COUNT=3 PLAYWRIGHT_SHARD_INDEX=2 playwright test",
+    "test:e2e:shard3": "PLAYWRIGHT_SHARD_COUNT=3 PLAYWRIGHT_SHARD_INDEX=3 playwright test"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/e2e_tests/playwright.config.js
+++ b/e2e_tests/playwright.config.js
@@ -77,4 +77,12 @@ export default defineConfig({
   //   url: 'http://localhost:3000',
   //   reuseExistingServer: !process.env.CI,
   // },
+
+  // Add sharding configuration
+  ...(process.env.PLAYWRIGHT_SHARD_COUNT && process.env.PLAYWRIGHT_SHARD_INDEX && {
+    shard: {
+      total: parseInt(process.env.PLAYWRIGHT_SHARD_COUNT, 10),
+      current: parseInt(process.env.PLAYWRIGHT_SHARD_INDEX, 10),
+    },
+  }),
 });


### PR DESCRIPTION
I've modified `e2e_tests/playwright.config.js` to support sharding based on `PLAYWRIGHT_SHARD_COUNT` and `PLAYWRIGHT_SHARD_INDEX` environment variables.

I also added npm scripts to `e2e_tests/package.json` for running tests in 3 separate shards (`test:e2e:shard1` to `test:e2e:shard3`).

This change allows you to split the E2E test suite into multiple stages to reduce individual run times, aiming for approximately 400 seconds per shard.

Note: I encountered environmental issues that prevented Playwright browser dependency installation, which blocked me from verifying this sharding configuration. You should verify shard execution times and adjust the shard count in your own CI/CD or local environments if needed. Your CI/CD pipeline will also need to be updated to invoke these new sharded test scripts.